### PR TITLE
Feature/upgrades

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -22,8 +22,14 @@ public class GameManager : SingletonMonoBehavior<GameManager>
 
     public void SetPlayerHealth(int health)
     {
-        playerDied = true;
+        
         PlayerHealth = health;
+
+        if(PlayerHealth <= 0)
+        {
+            playerDied = true;
+            LoseGame();
+        }
     }
 
     public int GetPlayerHealth()

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -78,7 +78,6 @@ public class GameManager : SingletonMonoBehavior<GameManager>
         if (playerDied)
         {
             playerDied = false;
-            ResetGame();
             return;
         }
 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,11 +1,19 @@
 using UnityEngine;
 using System;
 using System.Collections;
+using NUnit.Framework;
+using System.Collections.Generic;
 
 public class Player : MonoBehaviour
 {
-    [SerializeField] private float speed;    // base movement speed (will be overridden based on MoveSpeed level)
-    [SerializeField] private int health = 1;
+    //   [SerializeField] private InputManager inputManager;
+    [SerializeField] private float speed;
+    private int health;
+
+    public GameObject heartPrefab;
+    private List<GameObject> hearts = new List<GameObject>();
+
+
     public float pauseDuration = 2f;
 
     public GameObject bulletPrefab;
@@ -18,6 +26,12 @@ public class Player : MonoBehaviour
 
     public Animator animator;
 
+    private SpriteRenderer spriteRenderer;
+    private SpriteRenderer spriteRendererEngine;
+
+    private Color originalColor;
+    private Color engineColor;
+
     void Start()
     {
         // Apply MoveSpeed upgrade
@@ -25,20 +39,33 @@ public class Player : MonoBehaviour
         float baseSpeed = 5.0f;             // adjust as desired
         float incrementPerLevel = 1.0f;     // how much speed to add per level
         speed = baseSpeed + (moveSpeedLevel - 1) * incrementPerLevel;
-
-        // Initialize other components
-        rb = GetComponent<Rigidbody2D>();
         InputManager.Instance.OnMove.AddListener(MovePlayer);
         InputManager.Instance.OnShoot.AddListener(playerShoot);
         InputManager.Instance.StopShoot.AddListener(onStopShooting);
+        rb = GetComponent<Rigidbody2D>();
+        health = GameManager.Instance.GetPlayerHealth();
+
+        spriteRenderer = transform.Find("Main Ship - Engines - Base Engine - Powering").GetComponent<SpriteRenderer>();
+        spriteRendererEngine = transform.Find("Main Ship - Weapons - Auto Cannon").GetComponent<SpriteRenderer>();
+
+        originalColor = spriteRenderer.color;
+        engineColor = spriteRendererEngine.color;
+
+        SpawnHearts();
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
         Debug.Log("Trigger");
         health--;
+        if (health > 0) // Only flash if still alive
+        {
+            StartCoroutine(FlashRed(spriteRenderer, originalColor));
+            StartCoroutine(FlashRed(spriteRendererEngine, engineColor));
+        }
+        GameManager.Instance.SetPlayerHealth(health);
+        UpdateHearts();
     }
-
     void Update()
     {
         if (health <= 0 && !dead)
@@ -50,9 +77,13 @@ public class Player : MonoBehaviour
     public void Die()
     {
         dead = true;
+        // Disable the collider so the enemy can't be hit again
         GetComponent<Collider2D>().enabled = false;
-        StartCoroutine(PauseGame());
+
+        // StartCoroutine(PauseGame());
         Destroy(gameObject);
+
+        GameManager.Instance.LoseGame();
     }
 
     public void MovePlayer(Vector2 direction)
@@ -61,10 +92,12 @@ public class Player : MonoBehaviour
         {
             rb.linearVelocity = new Vector2(direction.x * speed, 0);
         }
+
         else
         {
             rb.linearVelocity = Vector2.zero;
         }
+
     }
 
     public void playerShoot()
@@ -75,6 +108,7 @@ public class Player : MonoBehaviour
         Instantiate(bulletPrefab, gunSpot2.transform.position, Quaternion.identity);
 
         animator.SetBool("isShoot", true);
+        GameSoundController.Instance.PlayShipShoot();
     }
 
     public void onStopShooting()
@@ -82,11 +116,37 @@ public class Player : MonoBehaviour
         animator.SetBool("isShoot", false);
     }
 
-    IEnumerator PauseGame()
+    private void SpawnHearts()
     {
-        Time.timeScale = 0;
-        yield return new WaitForSecondsRealtime(pauseDuration);
-        Time.timeScale = 1;
-        Debug.Log("Game resumed!");
+        foreach (GameObject heart in hearts)
+        {
+            Destroy(heart);
+        }
+        hearts.Clear();
+
+        for (int i = 0; i < health; i++)
+        {
+            Vector3 heartPosition = new Vector3(-8.5f + (i * 0.4f), -4.6f, 0);
+            GameObject heart = Instantiate(heartPrefab, heartPosition, Quaternion.identity);
+            hearts.Add(heart);
+        }
     }
+
+    private void UpdateHearts()
+    {
+        // Remove the last heart when health decreases
+        if (hearts.Count > health)
+        {
+            Destroy(hearts[hearts.Count - 1]);
+            hearts.RemoveAt(hearts.Count - 1);
+        }
+    }
+
+    private IEnumerator FlashRed(SpriteRenderer sp, Color originalC)
+    {
+        sp.color = new Color(1f, 0.3f, 0.3f, 0.5f); // Red with transparency
+        yield return new WaitForSeconds(0.1f);
+        sp.color = originalC;
+    }
+
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,66 +1,44 @@
 using UnityEngine;
 using System;
 using System.Collections;
-using NUnit.Framework;
-using System.Collections.Generic;
 
 public class Player : MonoBehaviour
 {
- //   [SerializeField] private InputManager inputManager;
-    [SerializeField] private float speed;
-    private int health;
-
-    public GameObject heartPrefab;
-    private List<GameObject> hearts = new List<GameObject>();
-
-
+    [SerializeField] private float speed;    // base movement speed (will be overridden based on MoveSpeed level)
+    [SerializeField] private int health = 1;
     public float pauseDuration = 2f;
 
     public GameObject bulletPrefab;
     private GameObject gunSpot;
     private GameObject gunSpot2;
 
-    private Boolean dead = false;
+    private bool dead = false;
 
     private Rigidbody2D rb;
 
     public Animator animator;
 
-    private SpriteRenderer spriteRenderer;
-    private SpriteRenderer spriteRendererEngine;
-
-    private Color originalColor;
-    private Color engineColor;
-
     void Start()
     {
+        // Apply MoveSpeed upgrade
+        int moveSpeedLevel = PlayerSkillManager.Instance.GetSkillLevel("MoveSpeed");
+        float baseSpeed = 5.0f;             // adjust as desired
+        float incrementPerLevel = 1.0f;     // how much speed to add per level
+        speed = baseSpeed + (moveSpeedLevel - 1) * incrementPerLevel;
+
+        // Initialize other components
+        rb = GetComponent<Rigidbody2D>();
         InputManager.Instance.OnMove.AddListener(MovePlayer);
         InputManager.Instance.OnShoot.AddListener(playerShoot);
         InputManager.Instance.StopShoot.AddListener(onStopShooting);
-        rb = GetComponent<Rigidbody2D>();
-        health = GameManager.Instance.GetPlayerHealth();
-
-        spriteRenderer = transform.Find("Main Ship - Engines - Base Engine - Powering").GetComponent<SpriteRenderer>();
-        spriteRendererEngine = transform.Find("Main Ship - Weapons - Auto Cannon").GetComponent<SpriteRenderer>(); 
-        
-        originalColor = spriteRenderer.color;
-        engineColor = spriteRendererEngine.color;
-
-        SpawnHearts();
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
         Debug.Log("Trigger");
         health--;
-        if (health > 0) // Only flash if still alive
-        {
-            StartCoroutine(FlashRed(spriteRenderer, originalColor));
-            StartCoroutine(FlashRed(spriteRendererEngine, engineColor));
-        }
-        GameManager.Instance.SetPlayerHealth(health);
-        UpdateHearts();
     }
+
     void Update()
     {
         if (health <= 0 && !dead)
@@ -72,27 +50,21 @@ public class Player : MonoBehaviour
     public void Die()
     {
         dead = true;
-        // Disable the collider so the enemy can't be hit again
         GetComponent<Collider2D>().enabled = false;
-
-        // StartCoroutine(PauseGame());
+        StartCoroutine(PauseGame());
         Destroy(gameObject);
-
-        GameManager.Instance.LoseGame();
     }
 
     public void MovePlayer(Vector2 direction)
     {
-        if(direction != Vector2.zero) 
+        if (direction != Vector2.zero)
         {
             rb.linearVelocity = new Vector2(direction.x * speed, 0);
         }
-
         else
         {
             rb.linearVelocity = Vector2.zero;
         }
-        
     }
 
     public void playerShoot()
@@ -103,7 +75,6 @@ public class Player : MonoBehaviour
         Instantiate(bulletPrefab, gunSpot2.transform.position, Quaternion.identity);
 
         animator.SetBool("isShoot", true);
-        GameSoundController.Instance.PlayShipShoot();
     }
 
     public void onStopShooting()
@@ -111,37 +82,11 @@ public class Player : MonoBehaviour
         animator.SetBool("isShoot", false);
     }
 
-    private void SpawnHearts()
+    IEnumerator PauseGame()
     {
-        foreach(GameObject heart in hearts)
-        {
-            Destroy(heart);
-        }
-        hearts.Clear();
-
-        for (int i =0; i < health; i++)
-        {
-            Vector3 heartPosition = new Vector3(-8.5f + (i * 0.4f), -4.6f, 0);
-            GameObject heart = Instantiate(heartPrefab, heartPosition, Quaternion.identity);
-            hearts.Add(heart);
-        }
+        Time.timeScale = 0;
+        yield return new WaitForSecondsRealtime(pauseDuration);
+        Time.timeScale = 1;
+        Debug.Log("Game resumed!");
     }
-
-    private void UpdateHearts()
-    {
-        // Remove the last heart when health decreases
-        if (hearts.Count > health)
-        {
-            Destroy(hearts[hearts.Count - 1]);
-            hearts.RemoveAt(hearts.Count - 1);
-        }
-    }
-
-    private IEnumerator FlashRed(SpriteRenderer sp, Color originalC)
-    {
-        sp.color = new Color(1f, 0.3f, 0.3f, 0.5f); // Red with transparency
-        yield return new WaitForSeconds(0.1f);
-        sp.color = originalC;
-    }
-
 }

--- a/Assets/Scripts/UpgradePanel.cs
+++ b/Assets/Scripts/UpgradePanel.cs
@@ -1,14 +1,16 @@
 using TMPro;
 using UnityEngine;
-using UnityEngine.SocialPlatforms.Impl;
 using UnityEngine.UI;
 
 public class UpgradePanel : MonoBehaviour
 {
     [Header("Upgrade Info")]
-    public string skillName;              // Set this in the Inspector
-    public TextMeshProUGUI levelText;                // Drag the Text component here
-    public Button upgradeButton;          // Drag the Button component here
+    public string skillName;                  // Set this in the Inspector
+    public TextMeshProUGUI levelText;         // Drag the "Level: X" text component here
+    public Button upgradeButton;              // Drag the Upgrade button component here
+
+    [Header("Cost Info")]
+    [SerializeField] private TextMeshProUGUI costInfoText; // An extra TextMeshProUGUI for "700 points required" message
 
     private void Start()
     {
@@ -23,10 +25,44 @@ public class UpgradePanel : MonoBehaviour
             Debug.LogError("PlayerSkillManager is not in the scene! Make sure it's loaded before this runs.", this);
 
         // Set up the button listener
-        upgradeButton?.onClick.AddListener(UpgradeSkill);
+        upgradeButton.onClick.AddListener(UpgradeSkill);
 
         // Set initial text
         UpdateLevelText();
+
+        // Optional: Set the initial costInfoText
+        if (costInfoText != null)
+        {
+            costInfoText.text = "700 points required to upgrade.";
+        }
+    }
+
+    private void Update()
+    {
+        // Enable or disable the button based on current score
+        if (upgradeButton != null)
+        {
+            int currentScore = ScoreManager.Instance.GetCurrentScore();
+
+            if (currentScore < 700)
+            {
+                upgradeButton.interactable = false;
+
+                if (costInfoText != null)
+                {
+                    costInfoText.text = "Not enough points! (700 required)";
+                }
+            }
+            else
+            {
+                upgradeButton.interactable = true;
+
+                if (costInfoText != null)
+                {
+                    costInfoText.text = "Press the button to upgrade (" + currentScore + " pts available)";
+                }
+            }
+        }
     }
 
     private void UpgradeSkill()
@@ -37,11 +73,17 @@ public class UpgradePanel : MonoBehaviour
             return;
         }
 
-        if (ScoreManager.Instance.GetCurrentScore() <= 700)
+        // Check again before upgrading, in case score changed
+        int currentScore = ScoreManager.Instance.GetCurrentScore();
+        if (currentScore >= 700)
         {
             PlayerSkillManager.Instance.UpgradeSkill(skillName);
-            ScoreManager.Instance.SetScore(ScoreManager.Instance.GetCurrentScore() - 700); 
+            ScoreManager.Instance.SetScore(currentScore - 700);
             UpdateLevelText();
+        }
+        else
+        {
+            Debug.Log("Not enough score to upgrade!");
         }
     }
 

--- a/Assets/_Scenes/SkillShop.unity
+++ b/Assets/_Scenes/SkillShop.unity
@@ -640,6 +640,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1596486647}
+  - {fileID: 1296869399}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1512,6 +1513,93 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1296869398
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1296869399}
+  - component: {fileID: 1296869400}
+  m_Layer: 0
+  m_Name: blue-preview_0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1296869399
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1296869398}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1}
+  m_LocalScale: {x: 133.92, y: 133.92, z: 133.92}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 386262842}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1296869400
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1296869398}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2130163334996902406, guid: 2c9f2c1a470274caeb8ef99511c7aabc, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 8.16, y: 4.8}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1596486646
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Scenes/SkillShop.unity
+++ b/Assets/_Scenes/SkillShop.unity
@@ -405,6 +405,146 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 253208266}
   m_CullTransparentMesh: 1
+--- !u!1 &379447180
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 379447181}
+  - component: {fileID: 379447183}
+  - component: {fileID: 379447182}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &379447181
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379447180}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 528723748}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &379447182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379447180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Upgrade your movement speed for 700 points!
+
+
+    Press Enter key to continue
+    to the next level.'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 3
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &379447183
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379447180}
+  m_CullTransparentMesh: 1
 --- !u!1 &386262838
 GameObject:
   m_ObjectHideFlags: 0
@@ -536,7 +676,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 379447181}
   m_Father: {fileID: 1841019262}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1531,6 +1672,7 @@ MonoBehaviour:
   skillName: MoveSpeed
   levelText: {fileID: 832844809}
   upgradeButton: {fileID: 2098621202}
+  costInfoText: {fileID: 0}
 --- !u!114 &1841019264
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Scenes/SkillShop.unity
+++ b/Assets/_Scenes/SkillShop.unity
@@ -639,7 +639,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Upgrade 1
+  m_text: Upgrading Move Speed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -1488,7 +1488,7 @@ GameObject:
   - component: {fileID: 1841019264}
   - component: {fileID: 1841019263}
   m_Layer: 5
-  m_Name: UpgradePanel 1
+  m_Name: UpgradePanel (MoveSpeed)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1528,7 +1528,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a54c39f372d7a46eea8088099aa435d8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  skillName: Test
+  skillName: MoveSpeed
   levelText: {fileID: 832844809}
   upgradeButton: {fileID: 2098621202}
 --- !u!114 &1841019264


### PR DESCRIPTION
**Summary**
This PR adds clear instructions in the Skill Shop UI, including the text "Upgrade your movement speed for 700 points!" and “Press Enter to proceed to the next stage.” These messages guide players on how to spend points for upgrades and how to continue to the next level.

**Changes**
- Updated UI text in the Skill Shop panel to indicate the 700-point requirement for upgrading movement speed.
- Added a prompt instructing players to press Enter to advance to the next stage.
- The upgrade button can only be pressed when the player have at least 700 points


<img width="824" alt="Screenshot 2025-03-31 at 22 18 07" src="https://github.com/user-attachments/assets/e93582ef-b380-477c-8a8b-bc4a0e93a1db" />
